### PR TITLE
fix: Lrc.format generating corrupt result

### DIFF
--- a/lib/src/lrc_main.dart
+++ b/lib/src/lrc_main.dart
@@ -279,12 +279,13 @@ class LrcLine {
     ///function to add leading zeros
     String f(int x) => x.toString().padLeft(2, '0');
 
-    var minutes = timestamp.inMinutes,
+    final minutes = timestamp.inMinutes,
         seconds = timestamp.inSeconds - (minutes * 60),
-        milliseconds =
-            timestamp.inMilliseconds - ((minutes * 60000) + (seconds * 1000));
+        hundredths = (timestamp.inMilliseconds -
+                ((minutes * 60000) + (seconds * 1000))) ~/
+            10;
 
-    return '[${f(minutes)}:${f(seconds)}:${f(milliseconds)}]$lyrics';
+    return '[${f(minutes)}:${f(seconds)}.${f(hundredths)}]$lyrics';
   }
 
   @override


### PR DESCRIPTION
Hi! First of all, thanks for the awesome package.

The [`Lrc.format`](https://github.com/Yivan000/lrc/blob/3ca8720c1e91e5575a312e14d76112a662e9d3f6/lib/src/lrc_main.dart#L60-L81) methods seems to result in invalid `.lrc`.

- The last timestamp element contains hundredths of a second & not milliseconds.
- A period (`.`) is used to separate it, instead of a colon (`:`).

See: https://en.wikipedia.org/wiki/LRC_(file_format)

This resulted in [`Lrc.isValid`](https://github.com/Yivan000/lrc/blob/3ca8720c1e91e5575a312e14d76112a662e9d3f6/lib/src/lrc_main.dart#L216-L219) to return `false` on the text generated by package itself.

<hr>

Lastly, thanks again. Have a great day!